### PR TITLE
Add config switch for legacy sensor attribute

### DIFF
--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -222,9 +222,11 @@ time etc. The following attributes are standardized across all readers:
   :class:`~pyresample.geometry.SwathDefinition` if data is geolocated. Areas are used for gridded
   projected data and Swaths when data must be described by individual longitude/latitude
   coordinates. See the Coordinates section below.
-* ``sensor``: The name of the sensor that recorded the data. For full support through Satpy this
-  should be all lowercase. If the dataset is the result of observations from multiple sensors a
-  ``set`` object can be used to specify more than one sensor name.
+* ``instruments`` (previously ``sensor`` in Satpy < v1.0): Names of instruments that recorded the
+  data, stored in a ``set`` object. Starting with Satpy v1.0 the instrument names follow WMO OSCAR
+  naming conventions. To facilitate the transision, you can get the ``sensor`` attribute back by
+  setting ``satpy.config.set(legacy_sensor_attribute=True)``. This config switch will be removed
+  in Satpy v1.1.
 * ``reader``: The name of the Satpy reader that produced the dataset.
 * ``orbital_parameters``: Dictionary of orbital parameters describing the satellite's position.
   See the :ref:`orbital_parameters` section below for more information.

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -222,11 +222,27 @@ time etc. The following attributes are standardized across all readers:
   :class:`~pyresample.geometry.SwathDefinition` if data is geolocated. Areas are used for gridded
   projected data and Swaths when data must be described by individual longitude/latitude
   coordinates. See the Coordinates section below.
-* ``instruments`` (previously ``sensor`` in Satpy < v1.0): Names of instruments that recorded the
-  data, stored in a ``set`` object. Starting with Satpy v1.0 the instrument names follow WMO OSCAR
-  naming conventions. To facilitate the transision, you can get the ``sensor`` attribute back by
-  setting ``satpy.config.set(legacy_sensor_attribute=True)``. This config switch will be removed
-  in Satpy v1.1.
+* ``sensor``: The name of the sensor that recorded the data. For full support through Satpy this
+  should be all lowercase. If the dataset is the result of observations from multiple sensors a
+  ``set`` object can be used to specify more than one sensor name.
+
+  .. versionremoved:: 1.0
+
+    The ``sensor`` attribute has been replaced by ``instruments`` in Satpy v1.0. During
+    a transition phase the attribute can be restored by setting
+
+    .. code-block:: python
+
+      import satpy
+      satpy.config.set(legacy_sensor_attribute=True)
+
+    This option will be removed in Satpy v1.1.
+
+* ``instruments``: Names of instruments that recorded the data, stored in a ``set`` object.
+  Instrument names follow the WMO OSCAR naming conventions.
+
+  .. versionadded:: 1.0
+
 * ``reader``: The name of the Satpy reader that produced the dataset.
 * ``orbital_parameters``: Dictionary of orbital parameters describing the satellite's position.
   See the :ref:`orbital_parameters` section below for more information.

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -54,7 +54,8 @@ _CONFIG_DEFAULTS = {
     "readers": {
         "clip_negative_radiances": False,
     },
-    "instruments_key": "sensor"
+    "instruments_key": "sensor",
+    "legacy_sensor_attribute": False
 }
 
 # Satpy main configuration object

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -29,6 +29,7 @@ import xarray as xr
 from pyresample.geometry import AreaDefinition, BaseDefinition, CoordinateDefinition, SwathDefinition
 from xarray import DataArray
 
+import satpy
 import satpy._instruments as inst_utils
 from satpy.area import get_area_def
 from satpy.composites.config_loader import load_compositor_configs_for_sensors
@@ -841,7 +842,27 @@ class Scene:
         """Get a dataset or create a new 'slice' of the Scene."""
         if isinstance(key, tuple):
             return self.slice(key)
+        # 8< v1.1
+        data_array = self._datasets[key]
+        if self._should_add_legacy_sensor_attribute(data_array):
+            self._set_legacy_sensor_attribute(data_array)
+            return data_array
+        # >8 v1.1
         return self._datasets[key]
+
+    # 8< v1.1
+    def _should_add_legacy_sensor_attribute(self, data_array: xr.DataArray) -> bool:
+        instruments = inst_utils.get_instruments_from_attrs(data_array.attrs)
+        return bool(instruments) and satpy.config.get("legacy_sensor_attribute")
+
+    def _set_legacy_sensor_attribute(self, data_array: xr.DataArray) -> None:
+        instruments = inst_utils.get_instruments_from_attrs(data_array.attrs)
+        if len(instruments) == 1:
+            # In satpy < v1.0 single sensors are provided as string
+            data_array.attrs["sensor"] = inst_utils.wmo_to_internal(list(instruments)[0])
+        else:
+            data_array.attrs["sensor"] = {inst_utils.wmo_to_internal(inst) for inst in instruments}
+    # >8 v1.1
 
     def __setitem__(self, key, value):
         """Add the item to the scene."""

--- a/satpy/tests/scene_tests/test_data_access.py
+++ b/satpy/tests/scene_tests/test_data_access.py
@@ -21,6 +21,7 @@ import pytest
 import xarray as xr
 from dask import array as da
 
+import satpy
 from satpy import Scene
 from satpy.dataset.dataid import default_id_keys_config
 from satpy.tests.utils import FAKE_FILEHANDLER_END, FAKE_FILEHANDLER_START, make_cid, make_dataid
@@ -393,3 +394,29 @@ class TestComputePersist:
         scene.load(["ds1"])
         scene = scene.chunk(chunks=2)
         assert scene["ds1"].data.chunksize == (2, 2)
+
+
+class TestLegacySensorAttribute:
+    """Tests for legacy sensor attribute."""
+
+    @pytest.mark.parametrize(
+        ("instruments", "expected"),
+        [
+            ({"inst1"}, "inst1"),
+            ({"inst1", "inst2"}, {"inst1", "inst2"})
+        ]
+    )
+    def test_getting_dataset_with_sensor_attribute(self, instruments, expected):
+        """Test getting dataset with sensor attribute."""
+        scene = Scene()
+        scene["ds"] = xr.DataArray(attrs={"instruments": instruments})
+        assert "sensor" not in scene["ds"].attrs
+        with satpy.config.set(legacy_sensor_attribute=True):
+            assert scene["ds"].attrs["sensor"] == expected
+
+    def test_no_instruments_no_sensor(self):
+        """Test setting sensor only if instruments are present."""
+        scene = Scene()
+        scene["ds"] = xr.DataArray()
+        with satpy.config.set(legacy_sensor_attribute=True):
+            assert "sensor" not in scene["ds"].attrs


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Add config switch to get legacy `sensor` attribute back. To be merged into https://github.com/pytroll/satpy/pull/3390.

