### PR TITLE
WMO Instruments Part 3.2: Cosmetics

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -328,7 +328,7 @@ Simple RGB composite
 This is the overview composite shown in the first code example above
 using :class:`satpy.composites.core.GenericCompositor`::
 
-    sensor_name: visir
+    instrument: visir
 
     composites:
       overview:
@@ -341,10 +341,10 @@ using :class:`satpy.composites.core.GenericCompositor`::
 
 For an instrument specific version (here MSG/SEVIRI), we should use
 the channel _names_ instead of wavelengths.  Note also that the
-sensor_name is now combination of visir and seviri, which means that
+instrument is now combination of visir and seviri, which means that
 it extends the generic visir composites::
 
-    sensor_name: visir/seviri
+    instrument: visir/seviri
 
     composites:
 
@@ -357,7 +357,7 @@ it extends the generic visir composites::
         standard_name: overview
 
 In the following examples only the composite receipes are shown, and
-the header information (sensor_name, composites) and intendation needs
+the header information (instrument, composites) and intendation needs
 to be added.
 
 Using modifiers

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -183,9 +183,20 @@ def _load_config(composite_configs):
         with open(composite_config, "r", encoding="utf-8") as conf_file:
             recursive_dict_update(conf, yaml.load(conf_file, Loader=UnsafeLoader))
     try:
-        sensor_name = conf["sensor_name"]
+        sensor_name = conf["instrument"]
     except KeyError:
-        logger.debug('No "sensor_name" tag found in %s, skipping.',
+        # 8< v1.0
+        sensor_name_legacy = conf.get("sensor_name")
+        if sensor_name_legacy:
+            warnings.warn(
+                "The 'sensor_name' composite property is deprecated and "
+                "will be ignored in Satpy v1.0. Use 'instrument' instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+            sensor_name = sensor_name_legacy
+        # >8 v1.0
+        logger.debug('No "instrument" tag found in %s, skipping.',
                      composite_configs)
         return {}, {}, {}
 

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/abi
+instrument: visir/abi
 
 modifiers:
   rayleigh_corrected_crefl:

--- a/satpy/etc/composites/agri.yaml
+++ b/satpy/etc/composites/agri.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/agri
+instrument: visir/agri
 
 composites:
   green:

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/ahi
+instrument: visir/ahi
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/ami
+instrument: visir/ami
 
 composites:
   green_raw:

--- a/satpy/etc/composites/amsr2.yaml
+++ b/satpy/etc/composites/amsr2.yaml
@@ -1,4 +1,4 @@
-sensor_name: amsr2
+instrument: amsr2
 
 composites:
   rgb_color:

--- a/satpy/etc/composites/atms.yaml
+++ b/satpy/etc/composites/atms.yaml
@@ -1,4 +1,4 @@
-sensor_name: atms
+instrument: atms
 
 composites:
   mw183_humidity:

--- a/satpy/etc/composites/avhrr-3.yaml
+++ b/satpy/etc/composites/avhrr-3.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/avhrr-3
+instrument: visir/avhrr-3
 
 composites:
 

--- a/satpy/etc/composites/ec_msi.yaml
+++ b/satpy/etc/composites/ec_msi.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/ec_msi
+instrument: visir/ec_msi
 
 
 modifiers:

--- a/satpy/etc/composites/epic.yaml
+++ b/satpy/etc/composites/epic.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/epic
+instrument: visir/epic
 
 modifiers:
   sunz_corrected:

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/fci
+instrument: visir/fci
 
 composites:
   ### L2

--- a/satpy/etc/composites/ghi.yaml
+++ b/satpy/etc/composites/ghi.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/ghi
+instrument: visir/ghi
 
 composites:
   true_color:

--- a/satpy/etc/composites/glm.yaml
+++ b/satpy/etc/composites/glm.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/glm
+instrument: visir/glm
 composites:
   C14_flash_extent_density:
     compositor: !!python/name:satpy.composites.fill.BackgroundCompositor

--- a/satpy/etc/composites/goes_imager.yaml
+++ b/satpy/etc/composites/goes_imager.yaml
@@ -1,5 +1,5 @@
 # XXX arb
-sensor_name: visir/goes_imager
+instrument: visir/goes_imager
 
 composites:
   overview:

--- a/satpy/etc/composites/hsaf.yaml
+++ b/satpy/etc/composites/hsaf.yaml
@@ -1,4 +1,4 @@
-sensor_name: hsaf
+instrument: hsaf
 
 composites:
   instantaneous_rainrate_3:

--- a/satpy/etc/composites/insat3d_img.yaml
+++ b/satpy/etc/composites/insat3d_img.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/insat_img
+instrument: visir/insat_img
 
 composites:
   cloud_phase_distinction:

--- a/satpy/etc/composites/li.yaml
+++ b/satpy/etc/composites/li.yaml
@@ -1,7 +1,7 @@
 ---
 # we use li only here, and not visir/li, since the second can cause dependency issues when creating composites
 # combined with imagers in a multi-reader Scene. visir composites do not apply to LI anyway.
-sensor_name: li
+instrument: li
 
 # these are tentative recipes that will need to be further tuned as we gain experience with LI data
 composites:

--- a/satpy/etc/composites/mersi-1.yaml
+++ b/satpy/etc/composites/mersi-1.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi-1
+instrument: visir/mersi-1
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/mersi-2.yaml
+++ b/satpy/etc/composites/mersi-2.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi-2
+instrument: visir/mersi-2
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/mersi-3.yaml
+++ b/satpy/etc/composites/mersi-3.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi-3
+instrument: visir/mersi-3
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/mersi-ll.yaml
+++ b/satpy/etc/composites/mersi-ll.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi-ll
+instrument: visir/mersi-ll
 
 composites:
 

--- a/satpy/etc/composites/mersi-rm.yaml
+++ b/satpy/etc/composites/mersi-rm.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi-rm
+instrument: visir/mersi-rm
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/mhs.yaml
+++ b/satpy/etc/composites/mhs.yaml
@@ -1,4 +1,4 @@
-sensor_name: mhs
+instrument: mhs
 
 composites:
   mw183_humidity:

--- a/satpy/etc/composites/microwave.yaml
+++ b/satpy/etc/composites/microwave.yaml
@@ -1,1 +1,1 @@
-sensor_name: microwave
+instrument: microwave

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/modis
+instrument: visir/modis
 modifiers:
   rayleigh_corrected_crefl:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector

--- a/satpy/etc/composites/msu-gs.yaml
+++ b/satpy/etc/composites/msu-gs.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/msu-gs
+instrument: visir/msu-gs
 
 composites:
   overview_raw:

--- a/satpy/etc/composites/msu_gsa.yaml
+++ b/satpy/etc/composites/msu_gsa.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/msu_gsa
+instrument: visir/msu_gsa
 
 composites:
   overview_raw:

--- a/satpy/etc/composites/mwr.yaml
+++ b/satpy/etc/composites/mwr.yaml
@@ -1,4 +1,4 @@
-sensor_name: microwave/mwr
+instrument: microwave/mwr
 
 composites:
   mw183_humidity:

--- a/satpy/etc/composites/oci.yaml
+++ b/satpy/etc/composites/oci.yaml
@@ -1,1 +1,1 @@
-sensor_name: visir/oci
+instrument: visir/oci

--- a/satpy/etc/composites/olci.yaml
+++ b/satpy/etc/composites/olci.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/olci
+instrument: visir/olci
 
 
 modifiers:

--- a/satpy/etc/composites/oli_tirs.yaml
+++ b/satpy/etc/composites/oli_tirs.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/oli_tirs
+instrument: visir/oli_tirs
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/sar-c.yaml
+++ b/satpy/etc/composites/sar-c.yaml
@@ -1,1 +1,1 @@
-sensor_name: sar/sar-c
+instrument: sar/sar-c

--- a/satpy/etc/composites/sar.yaml
+++ b/satpy/etc/composites/sar.yaml
@@ -1,4 +1,4 @@
-sensor_name: sar
+instrument: sar
 
 composites:
   sar-ice:

--- a/satpy/etc/composites/scatterometer.yaml
+++ b/satpy/etc/composites/scatterometer.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/scatterometer
+instrument: visir/scatterometer
 
 composites:
   scat_wind_speed:

--- a/satpy/etc/composites/sen2_msi.yaml
+++ b/satpy/etc/composites/sen2_msi.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/sen2_msi
+instrument: visir/sen2_msi
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/seviri
+instrument: visir/seviri
 
 modifiers:
   sunz_corrected:

--- a/satpy/etc/composites/sgli.yaml
+++ b/satpy/etc/composites/sgli.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/sgli
+instrument: visir/sgli
 
 
 modifiers:

--- a/satpy/etc/composites/slstr.yaml
+++ b/satpy/etc/composites/slstr.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/slstr
+instrument: visir/slstr
 composite_identification_keys:
   name:
     required: true

--- a/satpy/etc/composites/tropomi.yaml
+++ b/satpy/etc/composites/tropomi.yaml
@@ -1,4 +1,4 @@
-sensor_name: tropomi
+instrument: tropomi
 
 composites:
 

--- a/satpy/etc/composites/vii.yaml
+++ b/satpy/etc/composites/vii.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/vii
+instrument: visir/vii
 modifiers:
   nir_reflectance:
     modifier: !!python/name:satpy.modifiers.NIRReflectance

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/viirs
+instrument: visir/viirs
 
 modifiers:
   rayleigh_corrected_crefl:

--- a/satpy/etc/composites/virr.yaml
+++ b/satpy/etc/composites/virr.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/virr
+instrument: visir/virr
 
 modifiers:
   sunz_corrected:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir
+instrument: visir
 composite_identification_keys:
   name:
     required: true

--- a/satpy/modifiers/parallax.py
+++ b/satpy/modifiers/parallax.py
@@ -454,7 +454,7 @@ class ParallaxCorrectionModifier(ModifierBase):
     To use this, add to ``composites/visir.yaml`` within ``SATPY_CONFIG_PATH``
     something like::
 
-        sensor_name: visir
+        instrument: visir
 
         modifiers:
           parallax_corrected:

--- a/satpy/tests/compositor_tests/test_config_loader.py
+++ b/satpy/tests/compositor_tests/test_config_loader.py
@@ -17,7 +17,12 @@
 
 """Tests for compositor config handling."""
 
+from typing import Optional
+
+import pytest
+
 import satpy
+from satpy.composites.config_loader import load_compositor_configs_for_sensors
 
 
 def test_bad_sensor_yaml_configs(tmp_path):
@@ -26,8 +31,6 @@ def test_bad_sensor_yaml_configs(tmp_path):
     But the bad YAML also shouldn't crash composite configuration loading.
 
     """
-    from satpy.composites.config_loader import load_compositor_configs_for_sensors
-
     comp_dir = tmp_path / "composites"
     comp_dir.mkdir()
     comp_yaml = comp_dir / "fake_sensor.yaml"
@@ -40,19 +43,44 @@ def test_bad_sensor_yaml_configs(tmp_path):
         assert "fake_composite" not in comps["fake_sensor"]
 
 
-def _create_fake_composite_config(yaml_filename: str):
+def _create_fake_composite_config(yaml_filename: str, extra_content: Optional[dict]=None):
     import yaml
 
     from satpy.composites.aux_data import StaticImageCompositor
-
+    content = {
+        "composites": {
+            "fake_composite": {
+                "compositor": StaticImageCompositor,
+                "url": "http://example.com/image.png",
+            }
+        }
+    }
+    if extra_content:
+        content.update(extra_content)
     with open(yaml_filename, "w") as comp_file:
-        yaml.dump({
-            "composites": {
-                "fake_composite": {
-                    "compositor": StaticImageCompositor,
-                    "url": "http://example.com/image.png",
-                },
-            },
-        },
-            comp_file,
-        )
+        yaml.dump(content, comp_file)
+
+
+# 8< v1.0
+class TestUserConfigWithDeprecatedSensorNameProperty:
+    """Test loading user config with deprecated sensor_name property."""
+
+    @pytest.fixture
+    def user_comp_dir(self, tmp_path):
+        """Get directory with user composites."""
+        return tmp_path / "etc" / "composites"
+
+    @pytest.fixture
+    def user_config_file(self, user_comp_dir):
+        """Write user config with old sensor_name property."""
+        filename = user_comp_dir / "myinstrument.yaml"
+        user_comp_dir.mkdir(parents=True)
+        _create_fake_composite_config(filename, {"sensor_name": "myinstrument"})
+
+    def test_finding_user_config(self, user_comp_dir, user_config_file):
+        """Test loading user config with deprecated sensor_name property."""
+        with satpy.config.set(config_path=[str(user_comp_dir.parent)]):
+            with pytest.warns(DeprecationWarning, match="Use 'instrument' instead."):
+                comps, _ = load_compositor_configs_for_sensors(["MyInstrument"])
+            assert "MyInstrument" in comps
+# >8 v1.0

--- a/satpy/tests/etc/composites/fake_sensor.yaml
+++ b/satpy/tests/etc/composites/fake_sensor.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/fake_sensor
+instrument: visir/fake_sensor
 
 modifiers:
   mod1:

--- a/satpy/tests/modifier_tests/test_parallax.py
+++ b/satpy/tests/modifier_tests/test_parallax.py
@@ -693,7 +693,7 @@ class TestParallaxCorrectionModifier:
 
 
 _test_yaml_code = """
-sensor_name: visir
+instrument: visir
 
 modifiers:
   parallax_corrected:

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -168,7 +168,7 @@ def fake_composite_plugin_etc_path(tmp_path: Path) -> Iterator[Path]:
 def _write_fake_composite_yaml(yaml_filename: str) -> None:
     with open(yaml_filename, "w") as comps_file:
         comps_file.write("""
-    sensor_name: visir/fake_sensor
+    instrument: visir/fake_sensor
 
     composites:
         fake_composite:

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -53,7 +53,7 @@ def _setup_custom_composite_config(base_dir):
     composite_config = base_dir.mkdir("composites").join("visir.yaml")
     with open(composite_config, "w") as comp_file:
         yaml.dump({
-            "sensor_name": "visir",
+            "instrument": "visir",
             "modifiers": {
                 "test_modifier": {
                     "modifier": ReflectanceCorrector,


### PR DESCRIPTION
Rename `sensor_name` to `instrument` in composite YAML files. To be merged into https://github.com/pytroll/satpy/pull/3390. 

Users having `sensor_name` in their composites will be notified with a deprecation warning.